### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -99,6 +99,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
     env:
       PROJECT_FOLDER: ${{ github.repository}}/${{ github.ref_name }}
       DOCKER_COMPOSE_TEMPLATE_PATH: deploy/docker-compose.yml


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-client/security/code-scanning/6](https://github.com/horext/app-client/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the `Deploy` job to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the `Deploy` job only requires the `contents: read` permission for its operations (e.g., accessing repository metadata), we will set this as the minimal required permission. This change ensures that the `GITHUB_TOKEN` does not have unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
