### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,6 +44,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      packages: write
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:
@@ -99,6 +102,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
     env:
       PROJECT_FOLDER: ${{ github.repository}}/${{ github.ref_name }}
       DOCKER_COMPOSE_TEMPLATE_PATH: deploy/docker-compose.yml


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-client/security/code-scanning/5](https://github.com/horext/app-client/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions:
- The `release` job requires `contents: read` to check out the repository and `packages: write` to push Docker images.
- The `deploy` job requires `contents: read` to check out the repository and no additional permissions for its other steps.

The `permissions` block will be added at the job level to ensure each job has only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
