### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   ci:
     name: CI
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci.yml
     with:
       environment: prod


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-client/security/code-scanning/3](https://github.com/horext/app-client/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `ci` job. Since most basic CI workflows only require `contents: read` permissions, we will set this as the minimal required permission. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to perform the job, reducing the risk of unintended repository modifications.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
