### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   ci:
     name: CI
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci.yml
     with:
       environment: dev


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-client/security/code-scanning/1](https://github.com/horext/app-client/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `ci` job in the `.github/workflows/ci-cd-develop.yml` file. Since the `ci` job is likely performing basic CI tasks, it should only require `contents: read` permissions unless additional permissions are explicitly needed. This change ensures that the `ci` job adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
