### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, next, develop]
 
+# Set minimal permissions for the workflow
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   ci:
@@ -13,4 +17,3 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       environment: ${{ github.event.pull_request.base.ref == 'main' && 'local-prod' || 'local-dev' }}
-


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-client/security/code-scanning/2](https://github.com/horext/app-client/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow appears to trigger another workflow (`ci.yml`) and does not perform any direct actions requiring write permissions, we will set `contents: read` as the minimal permission. This ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
